### PR TITLE
Bump dependencies and add test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Execute Java tests
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Run tests with Maven
+        run: mvn --batch-mode verify

--- a/pom.xml
+++ b/pom.xml
@@ -15,13 +15,13 @@
   </licenses>
 
   <scm>
-    <url>https://github.com/acm19/aws-request-signing-apache-interceptor</url>
+    <url>https://github.com/awsdocs/aws-request-signing-apache-interceptor</url>
   </scm>
   <distributionManagement>
     <repository>
       <id>github</id>
-      <name>GitHub acm19 Apache Maven Packages</name>
-      <url>https://maven.pkg.github.com/acm19/aws-request-signing-apache-interceptor</url>
+      <name>GitHub AWS Apache Maven Packages</name>
+      <url>https://maven.pkg.github.com/awsdocs/aws-request-signing-apache-interceptor</url>
     </repository>
   </distributionManagement>
 
@@ -36,7 +36,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.7.1</version>
+        <version>5.7.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -44,7 +44,7 @@
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bom</artifactId>
-        <version>2.16.23</version>
+        <version>2.17.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -108,7 +108,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>

--- a/src/main/java/io/github/acm19/aws/interceptor/http/AwsRequestSigningApacheInterceptor.java
+++ b/src/main/java/io/github/acm19/aws/interceptor/http/AwsRequestSigningApacheInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/src/test/java/io/github/acm19/aws/interceptor/http/AwsRequestSigningApacheInterceptorTest.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/http/AwsRequestSigningApacheInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
+import java.util.NoSuchElementException;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
@@ -110,7 +111,7 @@ public class AwsRequestSigningApacheInterceptorTest {
             return SdkHttpFullRequest.builder()
                     .uri(request.getUri())
                     .method(SdkHttpMethod.GET)
-                    .contentStreamProvider(request.contentStreamProvider().orElseThrow())
+                    .contentStreamProvider(request.contentStreamProvider().orElseThrow(NoSuchElementException::new))
                     .headers(request.headers())
                     .appendHeader(name, value)
                     .appendHeader("resourcePath", request.getUri().getRawPath())

--- a/src/test/java/io/github/acm19/aws/interceptor/test/APIGatewaySample.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/test/APIGatewaySample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/src/test/java/io/github/acm19/aws/interceptor/test/AmazonElasticsearchServiceSample.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/test/AmazonElasticsearchServiceSample.java
@@ -1,7 +1,7 @@
 package io.github.acm19.aws.interceptor.test;
 
 /*
- * Copyright 2012-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at

--- a/src/test/java/io/github/acm19/aws/interceptor/test/Sample.java
+++ b/src/test/java/io/github/acm19/aws/interceptor/test/Sample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2012-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at


### PR DESCRIPTION
Bumps dependencies. Adds GitHub workflow to run the test on every push
to this repository. Fixes a test that wasn't working in Java 8. Replaces
some references to the original repo by the AWS ones.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
